### PR TITLE
Minor refactor

### DIFF
--- a/1_processing/README.md
+++ b/1_processing/README.md
@@ -1,5 +1,6 @@
 # Processing
-All samples were quantified in Salmon using both a PAO1 and PA14 references.
+The Raw data was quantified in Salmon using both PAO1 and PA14 references.
+For more information on the raw data is see this [paper](link TBD) with source code [here](https://github.com/hoganlab-dartmouth/pa-seq-compendia).
 
 To determine which samples are PAO1 versus PA14 we will use the median expression of accessory genes to determine if a sample is PAO1 or PA14.
 In our exploratory analysis we found that samples labeled as PAO1 based on SRA annotations had high PAO1 accessory gene expression.


### PR DESCRIPTION
This PR makes a few minor refactors. These changes include:

1. Adding documentation about the raw dataset that we use, that is described in another repo
2. Re-ordering directories since the common DEGs analysis depends on the core-core analysis
3. Remove PAO1 gene ids that were found in the PA14 compendium

Many files are changed because I made sure all the notebook ran successfully, but the main ones to look at are: